### PR TITLE
If Travis builds on a tag, get the dependencies from PyPi

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,23 +1,29 @@
 #!/usr/bin/env sh
 set -v
 
-export COMMIT_MSG=$(git show HEAD^2 -s)
-export PULP_PR_NUMBER=$(echo $COMMIT_MSG | grep -oP 'Required\ PR:\ https\:\/\/github\.com\/pulp\/pulp\/pull\/(\d+)' | awk -F'/' '{print $7}')
-
 pip install -r test_requirements.txt
 
 cd .. && git clone https://github.com/pulp/pulp.git
 
-if [ -n "$PULP_PR_NUMBER" ]; then
-  pushd pulp
-  git fetch origin +refs/pull/$PULP_PR_NUMBER/merge
-  git checkout FETCH_HEAD
-  popd
-fi
+# When building for a release tag, let the pip install of pulp_cookbook
+# below work out the dependencies using published PyPi packages, otherwise
+# install the development versions of the Pulp modules
+if [ -z "$TRAVIS_TAG" ]; then
+  export COMMIT_MSG=$(git show HEAD^2 -s)
+  export PULP_PR_NUMBER=$(echo $COMMIT_MSG | grep -oP 'Required\ PR:\ https\:\/\/github\.com\/pulp\/pulp\/pull\/(\d+)' | awk -F'/' '{print $7}')
 
-pushd pulp/common/ && pip install -e . && popd
-pushd pulp/pulpcore/ && pip install -e . && popd
-pushd pulp/plugin/ && pip install -e .  && popd
+  if [ -n "$PULP_PR_NUMBER" ]; then
+    pushd pulp
+    git fetch origin +refs/pull/$PULP_PR_NUMBER/merge
+    git checkout FETCH_HEAD
+    popd
+  fi
+
+  pushd pulp/common/ && pip install -e . && popd
+  pushd pulp/pulpcore/ && pip install -e . && popd
+  pushd pulp/plugin/ && pip install -e .  && popd
+
+fi
 
 cd pulp_cookbook
 pip install -e .


### PR DESCRIPTION
A release build must only depend on published Python packages, not the
latest master of Pulp core.