### PR TITLE
Use PublicationDistribution from pulpcore.plugin

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -229,7 +229,7 @@ Create a ``cookbook`` Publisher
 
     {
         "_created": "2019-03-30T22:37:31.851159Z",
-        "_distributions": [],
+        "distributions": [],
         "_href": "/pulp/api/v3/publishers/cookbook/cookbook/a985c28b-c7be-4e66-b10e-d3f799c23726/",
         "_last_updated": "2019-03-30T22:37:31.851227Z",
         "_type": "cookbook.cookbook",
@@ -256,7 +256,7 @@ Create a Publication
 Create a Distribution at 'foo' for the Publication
 --------------------------------------------------
 
-``$ http POST http://localhost:24817/pulp/api/v3/distributions/file/file/ name='baz' base_path='foo' publication=$PUBLICATION_HREF``
+``$ http POST http://localhost:24817/pulp/api/v3/distributions/cookbook/cookbook/ name='baz' base_path='foo' publication=$PUBLICATION_HREF``
 
 You can have a look at the published "universe" metadata now:
 
@@ -391,7 +391,7 @@ And update the distribution:
 
 .. code:: bash
 
-    export DISTRIBUTION_HREF=$(http :24817/pulp/api/v3/distributions/ | jq -r '.results[] | select(.name == "baz") | ._href')
+    export DISTRIBUTION_HREF=$(http :24817/pulp/api/v3/distributions/cookbook/cookbook/ | jq -r '.results[] | select(.name == "baz") | ._href')
     export LATEST_VERSION_HREF=$(http :24817$REPO_HREF | jq -r '._latest_version_href')
     export LATEST_PUBLICATION_HREF=$(http :24817/pulp/api/v3/publications/cookbook/cookbook/ | jq --arg LVH "$LATEST_VERSION_HREF" -r '.results[] | select(.repository_version == $LVH) | ._href')
     http PATCH :24817$DISTRIBUTION_HREF publication=$LATEST_PUBLICATION_HREF
@@ -483,7 +483,7 @@ Create a ``supermarket`` Publisher
 
     {
         "_created": "2019-03-30T23:01:44.703651Z",
-        "_distributions": [],
+        "distributions": [],
         "_href": "/pulp/api/v3/publishers/cookbook/cookbook/b9df1aef-8eda-4370-8199-93539f14455e/",
         "_last_updated": "2019-03-30T23:01:44.703671Z",
         "_type": "cookbook.cookbook",
@@ -514,7 +514,7 @@ publication:
 Create a Distribution at 'supermarket' for the Publication
 ----------------------------------------------------------
 
-``$ http POST http://localhost:24817/pulp/api/v3/distributions/ name='supermarket' base_path='supermarket' publication=$PUBLICATION_HREF``
+``$ http POST http://localhost:24817/pulp/api/v3/distributions/cookbook/cookbook/ name='supermarket' base_path='supermarket' publication=$PUBLICATION_HREF``
 
 You can have a look at the published "universe" metadata now:
 

--- a/pulp_cookbook/app/content/handler.py
+++ b/pulp_cookbook/app/content/handler.py
@@ -28,13 +28,13 @@ class CookbookContentHandler(Handler):
 
     async def handle_universe(self, request):
         """
-        Serve the '__universe__' metadata object at '/univere'.
+        Serve the '__universe__' metadata object at '/universe'.
 
         Since the '/universe' endpoint contains absolute URLs, translate
         the content of '__universe__' on the fly.
         """
         path = request.match_info["path"] + "/universe"
-        distribution = Handler._match_distribution(path)
+        distribution = Handler._match_distribution(path).cast()
         Handler._permit(request, distribution)
         publication = distribution.publication
         if not publication:

--- a/pulp_cookbook/app/models.py
+++ b/pulp_cookbook/app/models.py
@@ -6,7 +6,7 @@ import uuid
 
 from django.db import models
 
-from pulpcore.plugin.models import Content, Distribution, Publication, Publisher, Remote
+from pulpcore.plugin.models import Content, PublicationDistribution, Publication, Publisher, Remote
 from pulpcore.plugin.fields import JSONField
 
 
@@ -131,7 +131,7 @@ class CookbookPublication(Publication):
     TYPE = "cookbook"
 
 
-class CookbookDistribution(Distribution):
+class CookbookDistribution(PublicationDistribution):
     """
     Distribution for 'cookbook' content.
     """

--- a/pulp_cookbook/app/serializers.py
+++ b/pulp_cookbook/app/serializers.py
@@ -9,9 +9,10 @@ from rest_framework import serializers
 
 from pulpcore.plugin.serializers import (
     DetailRelatedField,
-    DistributionSerializer,
+    PublicationDistributionSerializer,
     PublicationSerializer,
     PublisherSerializer,
+    RelatedField,
     RemoteSerializer,
     SingleArtifactContentSerializer,
 )
@@ -104,6 +105,15 @@ class CookbookPublicationSerializer(PublicationSerializer):
     Serializer for Cookbook Publications.
     """
 
+    distributions = RelatedField(
+        help_text=_(
+            "This publication is currently being served as defined by these distributions."
+        ),
+        source="cookbookdistribution_set",
+        many=True,
+        read_only=True,
+        view_name="distributions-cookbook/cookbook-detail",
+    )
     publisher = DetailRelatedField(
         help_text=_("The publisher that created this publication."),
         queryset=CookbookPublisher.objects.all(),
@@ -111,7 +121,7 @@ class CookbookPublicationSerializer(PublicationSerializer):
     )
 
     class Meta:
-        fields = PublicationSerializer.Meta.fields + ("publisher",)
+        fields = PublicationSerializer.Meta.fields + ("distributions", "publisher")
         model = CookbookPublication
 
 
@@ -127,15 +137,15 @@ class CookbookBaseURLField(serializers.CharField):
         return "/".join((host.strip("/"), prefix.strip("/"), base_path.lstrip("/")))
 
 
-class CookbookDistributionSerializer(DistributionSerializer):
+class CookbookDistributionSerializer(PublicationDistributionSerializer):
     """Serializer for the Distribution."""
 
     base_url = CookbookBaseURLField(
         source="base_path",
         read_only=True,
-        help_text=_("The URL for accessing the publication as defined by this distribution."),
+        help_text=_("The URL for accessing the universe API as defined by this distribution."),
     )
 
     class Meta:
-        fields = DistributionSerializer.Meta.fields
+        fields = PublicationDistributionSerializer.Meta.fields
         model = CookbookDistribution

--- a/pulp_cookbook/app/utils.py
+++ b/pulp_cookbook/app/utils.py
@@ -6,7 +6,7 @@ from django.conf import settings
 
 
 def pulp_cookbook_content_path():
-    """Get base cotent path from configuration."""
+    """Get base content path from configuration."""
     components = settings.CONTENT_PATH_PREFIX.split("/")
     components[1] = "pulp_cookbook"
     return "/".join(components)

--- a/pulp_cookbook/app/viewsets.py
+++ b/pulp_cookbook/app/viewsets.py
@@ -23,7 +23,7 @@ from pulpcore.plugin.tasking import enqueue_with_reservation
 from pulpcore.plugin.viewsets import (
     ContentFilter,
     ContentViewSet,
-    DistributionViewSet,
+    BaseDistributionViewSet,
     RemoteViewSet,
     OperationPostponedResponse,
     PublicationViewSet,
@@ -181,7 +181,7 @@ class CookbookPublicationViewSet(PublicationViewSet):
         return OperationPostponedResponse(result, request)
 
 
-class CookbookDistributionViewSet(DistributionViewSet):
+class CookbookDistributionViewSet(BaseDistributionViewSet):
     """The ViewSet for the distribution endpoint."""
 
     endpoint_name = "cookbook"

--- a/pulp_cookbook/tests/functional/api/test_download_content.py
+++ b/pulp_cookbook/tests/functional/api/test_download_content.py
@@ -59,6 +59,11 @@ class DownloadContentTestCase(unittest.TestCase):
         distribution_href = dist_task["created_resources"][0]
         distribution = client.get(distribution_href)
         self.addCleanup(client.delete, distribution_href)
+
+        # Assert that the publication contains a reference to the distribution
+        publication = client.get(publication["_href"])
+        self.assertEqual(publication["distributions"], [distribution_href])
+
         return distribution
 
     def download_check(self, cfg, client, repo, distribution, policy):


### PR DESCRIPTION
pulp_cookbook now uses PublicationDistribution which causes its
users to only receive the fields they can actually use.