### PR TITLE
Adapt to remaining pulpcore 3.0.0rc8 changes

### DIFF
--- a/pulp_cookbook/app/viewsets.py
+++ b/pulp_cookbook/app/viewsets.py
@@ -5,6 +5,8 @@
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework.decorators import action
 
+from pulpcore.plugin.actions import ModifyRepositoryActionMixin
+
 from pulpcore.plugin.serializers import (
     AsyncOperationResponseSerializer,
     RepositorySyncURLSerializer,
@@ -62,7 +64,7 @@ class CookbookPackageContentViewSet(SingleArtifactContentUploadViewSet):
     filterset_class = CookbookPackageContentFilter
 
 
-class CookbookRepositoryViewSet(RepositoryViewSet):
+class CookbookRepositoryViewSet(ModifyRepositoryActionMixin, RepositoryViewSet):
     """
     Cookbook Repository Endpoint.
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     author="Simon Baatz",
     author_email="gmbnomis@gmail.com",
     url="https://github.com/gmbnomis/pulp_cookbook/",
-    install_requires=["pulpcore~=3.0rc7"],
+    install_requires=["pulpcore~=3.0rc8"],
     include_package_data=True,
     packages=find_packages(exclude=["test"]),
     classifiers=(


### PR DESCRIPTION
Adapt to https://github.com/pulp/pulpcore/pull/369 (Repository /modify
mixin) and https://github.com/pulp/pulpcore/pull/380 (Don't create a new
repository version if no content was added or removed).  No functional
changes.