### PR TITLE
Use Repository.finalize_new_version with cookbook repo_key

### DIFF
--- a/CHANGES/68.feature
+++ b/CHANGES/68.feature
@@ -1,0 +1,3 @@
+Add validation to repository versions: A repository version must not have
+entries with duplicate repo_keys. Remove the current check done at publication
+time.

--- a/pulp_cookbook/app/models/__init__.py
+++ b/pulp_cookbook/app/models/__init__.py
@@ -1,0 +1,9 @@
+# (C) Copyright 2019 Simon Baatz <gmbnomis@gmail.com>
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+from .content import CookbookPackageContent  # noqa
+from .publication import CookbookDistribution  # noqa
+from .publication import CookbookPublication  # noqa
+from .repository import CookbookRepository  # noqa
+from .repository import CookbookRemote  # noqa

--- a/pulp_cookbook/app/models/publication.py
+++ b/pulp_cookbook/app/models/publication.py
@@ -1,0 +1,28 @@
+# (C) Copyright 2019 Simon Baatz <gmbnomis@gmail.com>
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+
+from pulpcore.plugin.models import PublicationDistribution, Publication
+
+
+class CookbookPublication(Publication):
+    """
+    Publication for 'cookbook' content.
+    """
+
+    TYPE = "cookbook"
+
+    class Meta:
+        default_related_name = "%(app_label)s_%(model_name)s"
+
+
+class CookbookDistribution(PublicationDistribution):
+    """
+    Distribution for 'cookbook' content.
+    """
+
+    TYPE = "cookbook"
+
+    class Meta:
+        default_related_name = "%(app_label)s_%(model_name)s"

--- a/pulp_cookbook/app/models/repository.py
+++ b/pulp_cookbook/app/models/repository.py
@@ -1,0 +1,53 @@
+# (C) Copyright 2019 Simon Baatz <gmbnomis@gmail.com>
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+
+from django.contrib.postgres.fields import JSONField
+
+from pulpcore.plugin.models import Remote, Repository
+
+from pulp_cookbook.app.repo_version_utils import check_repo_version_constraint
+
+
+class CookbookRepository(Repository):
+    """
+    The "cookbook" repository type.
+    """
+
+    TYPE = "cookbook"
+
+    def finalize_new_version(self, new_version):
+        """
+        Ensure no added content contains the same `relative_path` as other content.
+
+        Args:
+            new_version (pulpcore.app.models.RepositoryVersion): The incomplete RepositoryVersion to
+                finalize.
+        Raises:
+            ValueError: When constraint is violated
+
+        """
+        check_repo_version_constraint(new_version)
+
+    class Meta:
+        default_related_name = "%(app_label)s_%(model_name)s"
+
+
+class CookbookRemote(Remote):
+    """
+    Remote for "cookbook" content.
+    """
+
+    TYPE = "cookbook"
+
+    cookbooks = JSONField(null=True)
+
+    def specifier_cookbook_names(self):
+        if self.cookbooks is None:
+            return None
+        else:
+            return set(self.cookbooks.keys())
+
+    class Meta:
+        default_related_name = "%(app_label)s_%(model_name)s"

--- a/pulp_cookbook/app/repo_version_utils.py
+++ b/pulp_cookbook/app/repo_version_utils.py
@@ -1,0 +1,26 @@
+# (C) Copyright 2019 Simon Baatz <gmbnomis@gmail.com>
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+from django.db.models import Count
+
+from pulp_cookbook.app.models import CookbookPackageContent
+
+
+def check_repo_version_constraint(repository_version):
+    """
+    Ensure that repo version fulfills repo_key_fields uniqueness.
+
+    Raises:
+        ValueError: When constraint is violated
+
+    """
+    fields = CookbookPackageContent.repo_key_fields
+    qs_content = CookbookPackageContent.objects.filter(pk__in=repository_version.content)
+    qs = qs_content.values(*fields).annotate(num_cookbooks=Count("pk")).filter(num_cookbooks__gt=1)
+    duplicates = [f"{res['name']} {res['version']}" for res in qs]
+    if duplicates:
+        duplicates_str = ", ".join(duplicates)
+        raise ValueError(
+            f"repository version would contain multiple versions of cookbooks: {duplicates_str}"
+        )

--- a/pulp_cookbook/app/tasks/synchronizing.py
+++ b/pulp_cookbook/app/tasks/synchronizing.py
@@ -70,7 +70,7 @@ class QueryExistingRepoContentAndArtifacts(Stage):
     existing saved Content units with the same key. The search is constrained to
     the content of the given repository version `new_version` and use the query
     :class:`~pulpcore.plugin.models.Content.repo_q()` and the key
-    :class:`~pulpcore.plugin.models.Content.repo_key_fields()`.
+    :class:`~pulpcore.plugin.models.Content.repo_key_fields`.
 
     Any existing Content objects found replace their "unsaved" counterpart in
     the :class:`~pulpcore.plugin.stages.DeclarativeContent` object.

--- a/pulp_cookbook/tests/functional/api/test_download_content.py
+++ b/pulp_cookbook/tests/functional/api/test_download_content.py
@@ -172,8 +172,9 @@ class DownloadContentTestCase(unittest.TestCase):
 
     def test_download_merged_on_demand_policy(self):
         #  When using non-immediate policy, content units can't be merged
-        #  (sha256 is unknown). Therefore, the publish task must fail.
+        #  (sha256 is unknown). Therefore, creating a repository version must fail.
         with self.assertRaisesRegex(
-            exceptions.TaskReportError, r"Publication would contain multiple versions of cookbooks:"
+            exceptions.TaskReportError,
+            r"repository version would contain multiple versions of cookbooks:",
         ):
             self.sync_merge_and_download_check(policy="on_demand")

--- a/pulp_cookbook/tests/functional/api/test_sync.py
+++ b/pulp_cookbook/tests/functional/api/test_sync.py
@@ -8,7 +8,7 @@ import unittest
 from pulp_smash import api, config
 from pulp_smash.exceptions import TaskReportError
 from pulp_smash.pulp3.constants import IMMEDIATE_DOWNLOAD_POLICIES, ON_DEMAND_DOWNLOAD_POLICIES
-from pulp_smash.pulp3.utils import delete_orphans, gen_remote, gen_repo, sync
+from pulp_smash.pulp3.utils import delete_orphans, gen_remote, gen_repo, modify_repo, sync
 
 from pulp_cookbook.tests.functional.constants import (
     fixture_u1,
@@ -150,7 +150,7 @@ class SyncCookbookRepoTestCase(unittest.TestCase):
         )
         repo = client.get(repo["pulp_href"])
         if exp_download_count:
-            # When we download the actual artifacts, the respective content unit will be replaced.
+            # When we download the actual artifacts, the respective content units will be replaced.
             # This looks like adding/deleting all cookbooks.
             self.assertNotEqual(latest_version_href, repo["latest_version_href"])
             self.assertListEqual(report["created_resources"], [repo["latest_version_href"]])
@@ -365,3 +365,41 @@ class SyncInvalidTestCase(unittest.TestCase):
         with self.assertRaises(TaskReportError) as context:
             sync(self.cfg, remote, repo, mirror=True)
         return context
+
+
+class RepoVersionConstraintValidationTestCase(unittest.TestCase):
+    """Test the check for repo version constraints."""
+
+    def test_publish_invalid_repo_version(self):
+        """Repo version containing two units with the same name and version can't be created."""
+        cfg = config.get_config()
+        delete_orphans(cfg)
+        client = api.Client(cfg, api.json_handler)
+
+        # Create repo u1 and sync partially
+        repo_u1 = client.post(COOKBOOK_REPO_PATH, gen_repo())
+        self.addCleanup(client.delete, repo_u1["pulp_href"])
+
+        body = gen_remote(fixture_u1.url, cookbooks={fixture_u1.example1_name: ""})
+        remote_u1 = client.post(COOKBOOK_REMOTE_PATH, body)
+        self.addCleanup(client.delete, remote_u1["pulp_href"])
+
+        sync(cfg, remote_u1, repo_u1, mirror=True)
+        repo_u1 = client.get(repo_u1["pulp_href"])
+
+        # Create repo u1_diff_digest and sync partially
+        repo_u1_diff_digest = client.post(COOKBOOK_REPO_PATH, gen_repo())
+        self.addCleanup(client.delete, repo_u1_diff_digest["pulp_href"])
+
+        body = gen_remote(fixture_u1_diff_digest.url, cookbooks={fixture_u1.example1_name: ""})
+        remote_u1_diff_digest = client.post(COOKBOOK_REMOTE_PATH, body)
+        self.addCleanup(client.delete, remote_u1_diff_digest["pulp_href"])
+
+        sync(cfg, remote_u1_diff_digest, repo_u1_diff_digest, mirror=True)
+        repo_u1_diff_digest = client.get(repo_u1_diff_digest["pulp_href"])
+
+        # Add a content unit from u1_diff_digest to u1 (duplicate name&version)
+        content_u1_diff_digest = get_cookbook_content(repo_u1_diff_digest)
+        self.assertTrue(content_u1_diff_digest)
+        with self.assertRaisesRegex(TaskReportError, "would contain multiple versions"):
+            modify_repo(cfg, repo_u1, add_units=[content_u1_diff_digest[0]])

--- a/pulp_cookbook/tests/functional/api/test_sync.py
+++ b/pulp_cookbook/tests/functional/api/test_sync.py
@@ -91,6 +91,14 @@ class SyncCookbookRepoTestCase(unittest.TestCase):
                 self.fail("Could not find 'Downloading Artifacts' stage in task report")
         return tasks[0]
 
+    def assert_initial_repo(self, repo):
+        """
+        Assert that we have an initial repo.
+
+        Initially, the latest version is the (special) empty version 0.
+        """
+        self.assertEqual(repo["latest_version_href"], repo["versions_href"] + "0/")
+
     def do_create_repo_and_sync(self, client, policy):
         """
         Create a repo and remote (fixture_u1) using `policy`. Sync the repo.
@@ -105,8 +113,9 @@ class SyncCookbookRepoTestCase(unittest.TestCase):
         remote = client.post(COOKBOOK_REMOTE_PATH, body)
         self.addCleanup(client.delete, remote["pulp_href"])
 
-        # Sync the full repository.
-        self.assertIsNone(repo["latest_version_href"])
+        # Sync the full repository:
+
+        self.assert_initial_repo(repo)
 
         all_cookbook_count = fixture_u1.cookbook_count()
         task = self.sync_and_inspect_task_report(remote, repo, all_cookbook_count, policy=policy)
@@ -260,7 +269,7 @@ class SyncCookbookRepoTestCase(unittest.TestCase):
         remote_u1 = client.post(COOKBOOK_REMOTE_PATH, body)
         self.addCleanup(client.delete, remote_u1["pulp_href"])
 
-        self.assertIsNone(repo_u1["latest_version_href"])
+        self.assert_initial_repo(repo_u1)
 
         example1_count = fixture_u1.cookbook_count([fixture_u1.example1_name])
         self.sync_and_inspect_task_report(remote_u1, repo_u1, example1_count)
@@ -278,7 +287,7 @@ class SyncCookbookRepoTestCase(unittest.TestCase):
         remote_u1_diff_digest = client.post(COOKBOOK_REMOTE_PATH, body)
         self.addCleanup(client.delete, remote_u1_diff_digest["pulp_href"])
 
-        self.assertIsNone(repo_u1_diff_digest["latest_version_href"])
+        self.assert_initial_repo(repo_u1_diff_digest)
 
         # u1 and u1_diff_digest must not share content: all cookbooks are added
         cookbook_count = fixture_u1_diff_digest.cookbook_count()

--- a/pulp_cookbook/tests/unit/test_publishing.py
+++ b/pulp_cookbook/tests/unit/test_publishing.py
@@ -7,16 +7,16 @@ from unittest.mock import Mock
 from django.test import TestCase
 
 from pulp_cookbook.app.models import CookbookPackageContent
-from pulp_cookbook.app.tasks.publishing import check_repo_version_constraint
+from pulp_cookbook.app.repo_version_utils import check_repo_version_constraint
 
 
-class PublishingCheckRepoVersionConstraintTestCase(TestCase):
+class CheckRepoVersionConstraintTestCase(TestCase):
     """Verify check_repo_version_constraint() method."""
 
-    def new_publication_version_content(self):
-        publication = Mock()
-        publication.repository_version.content = CookbookPackageContent.objects.all()
-        return publication
+    def new_version_content(self):
+        repository_version = Mock()
+        repository_version.content = CookbookPackageContent.objects.all()
+        return repository_version
 
     def test_check_repo_version_constraint_ok(self):
         CookbookPackageContent.objects.create(
@@ -29,7 +29,7 @@ class PublishingCheckRepoVersionConstraintTestCase(TestCase):
             name="c1", version="1.0.1", content_id_type="sha256", content_id="2", dependencies={}
         )
 
-        check_repo_version_constraint(self.new_publication_version_content())
+        check_repo_version_constraint(self.new_version_content())
 
     def test_check_repo_version_constraint_not_ok(self):
         CookbookPackageContent.objects.create(
@@ -48,7 +48,7 @@ class PublishingCheckRepoVersionConstraintTestCase(TestCase):
             name="c1", version="1.0.1", content_id_type="sha256", content_id="1", dependencies={}
         )
         with self.assertRaises(ValueError):
-            check_repo_version_constraint(self.new_publication_version_content())
+            check_repo_version_constraint(self.new_version_content())
 
     def test_check_repo_version_constraint_same_and_different_id_types_not_ok(self):
         CookbookPackageContent.objects.create(
@@ -60,4 +60,4 @@ class PublishingCheckRepoVersionConstraintTestCase(TestCase):
         )
 
         with self.assertRaises(ValueError):
-            check_repo_version_constraint(self.new_publication_version_content())
+            check_repo_version_constraint(self.new_version_content())


### PR DESCRIPTION
Add validation for Repository Versions: A repository version must not have
entries with duplicate repo_keys.

Remove the current check done at publication time.

See upstream: https://pulp.plan.io/issues/3541 and https://pulp.plan.io/issues/5706

Closes #68